### PR TITLE
new TEST for ComputeACF

### DIFF
--- a/shared/proc/ComputeACF.m
+++ b/shared/proc/ComputeACF.m
@@ -12,10 +12,10 @@ acf(ceil(length(acf)/2)) = 0;
 if isfield(cfg,'sided')
     cut_idx = ceil(length(acf)/2);
     switch cfg.sided
-        case 'one'
+        case 'one' % only uses data from center to end.  
             acf = acf(cut_idx:end);
             tvec = tvec(cut_idx:end);
-        case 'onezero'
+        case 'onezero' % keeps the length for convolution
             acf(1:cut_idx-1) = 0;
     end
 end

--- a/tests/proc/TEST_ComputeACF.m
+++ b/tests/proc/TEST_ComputeACF.m
@@ -1,0 +1,58 @@
+% setup
+rng(0); % for reproducibility
+
+% tuning variable: linear increase
+tuning_dt = 1/30; 
+tuning_var_tvec = 0:tuning_dt:100;
+tuning_var_data = linspace(80, 400, length(tuning_var_tvec));
+
+% spike train (logical)
+spike_dt = 0.001;
+spike_rate = 0.5;
+spike_tvec = 0:spike_dt:100;
+spike_data_binary = rand(size(spike_tvec)) > spike_rate;
+
+% spike train (continuous)
+spike_data_cont = rand(size(spike_tvec));
+
+cfg.bins = 0:10:640;
+cfg.interp = 'nearest';
+
+%% test that outputs have the expected size
+cfg_acf = [];
+cfg_acf.binsize = mean(diff(cfg.bins));
+
+[acf,tvec] = ComputeACF(cfg_acf,spike_data_binary); 
+assert(mean(diff(tvec)) == cfg_acf.binsize); % cfg.binsive should be the same as the tvec dt
+assert(tvec(ceil(end/2))==0) % tvec centered on 0
+assert(acf(ceil(end/2))==0) % acf centered on 0
+
+
+cfg_acf = [];
+cfg_acf.binsize = mean(diff(cfg.bins));
+cfg_acf.maxlag = 10000; 
+[acf,tvec] = ComputeACF(cfg_acf,spike_data_binary); 
+assert(mean(diff(tvec)) == cfg_acf.binsize); % cfg.binsive should be the same as the tvec dt
+assert(tvec(ceil(end/2))==0) % tvec centered on 0
+assert(acf(ceil(end/2))==0) % acf centered on 0
+
+cfg_acf = [];
+cfg_acf.binsize = mean(diff(cfg.bins));
+cfg_acf.maxlag = 10000; 
+cfg_acf.sided = 'one'; 
+[acf,tvec] = ComputeACF(cfg_acf,spike_data_binary); 
+assert(mean(diff(tvec)) == cfg_acf.binsize); % cfg.binsive should be the same as the tvec dt
+assert(tvec(ceil(end/2))~=0) % tvec not centered on 0
+assert(acf(ceil(end/2))~=0) % acf not centered on 0
+
+cfg_acf = [];
+cfg_acf.binsize = mean(diff(cfg.bins));
+cfg_acf.maxlag = 10000; 
+cfg_acf.sided = 'onezero'; 
+[acf,tvec] = ComputeACF(cfg_acf,spike_data_binary); 
+assert(mean(diff(tvec)) == cfg_acf.binsize); % cfg.binsive should be the same as the tvec dt
+assert(tvec(ceil(end/2))==0) % tvec not centered on 0
+assert(acf(ceil(end/2))==0) % acf not centered on 0
+assert(all(acf(1:ceil(end/2)) ==0)) % ensure all acf up to tvec 0 are zero
+
+


### PR DESCRIPTION
TEST for ComputeACF that uses all of the possible cfg input options.  Tests for data centering and bin sizes.  

additional: 
- minor annotations to ComputeACF